### PR TITLE
Fix query params when sending Guzzle client request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 php:
   - 7.1
   - 7.2
-  - 7.3
+  - '7.3.24'
 
 env:
   matrix:

--- a/src/Client.php
+++ b/src/Client.php
@@ -38,7 +38,11 @@ class Client implements IEXCloud
     public function send(RequestInterface $request, array $options = []): ResponseInterface
     {
         try {
-            return $this->client->send($request);
+            parse_str(parse_url($request->getUri(), PHP_URL_QUERY), $query);
+
+            return $this->client->send($request, [
+                'query' => array_merge($this->client->getConfig('query') ?? [], $query)
+            ]);
         }
         catch (ClientException $e) {
             throw WrongData::invalidValuesProvided($e->getMessage());


### PR DESCRIPTION
This fixes a bug where the `query` option set for the Guzzle client would [overwrite](https://docs.guzzlephp.org/en/6.5/request-options.html#query) any query params added to the passed `Request` object, which breaks requests such as `Batch` at the point of sending.

## Example

For `Batch`, the query params `symbols` and `types` were being dropped entirely by Guzzle in favour of the single `token` param set in the base client options.

![image](https://user-images.githubusercontent.com/2547783/106356985-50645c80-62fb-11eb-8e8b-08d0c5566824.png)

## Fix details

This fix explicitly merges the `query` option in the base client config with any params that are part of the received request URI, and assigns the merged result when the `send` method is called.

For the user, the ability to configure the `token` param (and others) at the client level is preserved.